### PR TITLE
Allow custom properties to be called as functions

### DIFF
--- a/.changeset/tough-items-tease.md
+++ b/.changeset/tough-items-tease.md
@@ -1,0 +1,5 @@
+---
+"corset": minor
+---
+
+Allows custom properties to be called as functions

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import { BindingSheet, SheetWithValues } from './sheet.js';
 import {
   AnyValue,
   BindValue,
+  CustomFunctionValue,
   DataValue,
   GetValue,
   IndexValue,
@@ -83,14 +84,19 @@ function getValue(ptr) {
     }
     case 4: {
       let fn = readString(mem32[ptrv32], mem32[ptrv32 + 1]);
-      if(!fnMap.has(fn)) {
-        throw new Error(`Unknown function ${fn}`);
-      }
       /** @type {ValueType} */
-      let ValueConstructor = fnMap.get(fn);
-
+      let ValueConstructor;
       /** @type {Value[]} */
       let args = [];
+      if(fnMap.has(fn)) {
+        ValueConstructor = fnMap.get(fn);
+      } else if(fn.startsWith('--')) {
+        ValueConstructor = CustomFunctionValue;
+        args.push(new VarValue(new AnyValue(fn)));
+      } else {
+        throw new Error(`Unknown function ${fn}`);
+      }
+
       let vptr = mem32[ptrv32 + 3];
       while(vptr) {
         args.push(getValue(vptr));

--- a/src/value.js
+++ b/src/value.js
@@ -62,7 +62,7 @@ export class VarValue extends ScopeLookupValue {
   /**
    *
    * @param {any} propValue
-   * @param {Value} fallbackValue
+   * @param {Value} [fallbackValue]
    */
   constructor(propValue, fallbackValue) {
     let propName = propValue.get();
@@ -174,5 +174,25 @@ export class DataValue {
       throw new Error('The data() function can only be used on HTMLElements.');
     }
     return /** @type {HTMLElement} */(element).dataset[prop];
+  }
+}
+
+/** @implements {Value} */
+export class CustomFunctionValue {
+  constructor(varValue, ...args) {
+    /** @type {Value} */
+    this.varValue = varValue;
+    /** @type {Value[]} */
+    this.args = args;
+  }
+  /**
+   * @param {Element} rootElement
+   * @param {Element} element
+   * @param {any[]} values
+   */
+  get(rootElement, element, values) {
+    let fn = this.varValue.get(rootElement, element, values);
+    let args = this.args.map(arg => arg.get(rootElement, element, values));
+    return fn(...args);
   }
 }

--- a/test/test-custom-property.js
+++ b/test/test-custom-property.js
@@ -68,3 +68,16 @@ QUnit.test('Dash property names work', assert => {
   bindings.update(root);
   assert.equal(root.firstElementChild.textContent, 'testing');
 });
+
+QUnit.test('Can be used as a function', assert => {
+  let root = document.createElement('main');
+  root.innerHTML = `<div id="app"></div>`;
+  let bindings = sheet`
+    #app {
+      --concat: ${(...args) => args.join('')};
+      text: --concat("one", " ", "two");
+    }
+  `;
+  bindings.update(root);
+  assert.equal(root.firstElementChild.textContent, 'one two');
+});


### PR DESCRIPTION
This allows custom properties to be called as functions:

```js
#app {
  --concat: ${(...args) => args.join('')};
  text: --concat("one", " ", "two");
}
```

I'm curious if this is a good idea or not. If CSS ever gets custom functions, would they would a little like this (obviously without the JS insertion)?  If it would likely be much different then this shouldn't be merged.

Curious what you think @propjockey?

Also want to point out that this doesn't solve global functions (those defined outside of a single sheet) and that's something I'd want to add as a followup.