### PR TITLE
Remove wrap/wrapAsync in favor of rebind

### DIFF
--- a/.changeset/mean-shrimps-lick.md
+++ b/.changeset/mean-shrimps-lick.md
@@ -1,0 +1,7 @@
+---
+"corset": minor
+---
+
+Replace wrap/wrapAsync with rebind
+
+This is a breaking change which removes wrap and wrapAsync with a new `rebind` function. Just call rebind any time state has change that necessitates calling `bind()` to get new values.

--- a/src/mount.js
+++ b/src/mount.js
@@ -48,10 +48,8 @@ function scopedCallback(mp, fn, ...args) {
 export function BehaviorContext(mp) {
   /** @type {Element} */
   this.element = mp.rootElement;
-  /** @type {(fn: CallbackFunction) => CallbackFunction} */
-  this.wrap = fn => scopedCallback.bind(null, mp, fn);
-  /** @type {(fn: CallbackFunction) => AsyncCallbackFunction} */
-  this.wrapAsync = fn => scopedAsyncCallback.bind(null, mp, fn);
+  /** @type {() => void} */
+  this.rebind = mp.update.bind(mp);
 }
 
 export class Mountpoint {

--- a/test/test-behavior.js
+++ b/test/test-behavior.js
@@ -258,15 +258,16 @@ QUnit.test('registerBehavior allows defining named behaviors', assert => {
   assert.equal(inner.textContent, 'works');
 });
 
-QUnit.test('wrap will wrap a function inside of the mountpoint', assert => {
+QUnit.test('`rebind` will rebind a function inside of the mountpoint', assert => {
   let root = document.createElement('main');
   root.innerHTML = `<div id="app"><div id="inner"></div></div>`;
   let run;
   class One {
-    constructor(_p, { wrap }) {
-      run = wrap(() => {
+    constructor(_p, { rebind }) {
+      run = () => {
         this.text = 'works';
-      });
+        rebind();
+      };
     }
 
     bind() {
@@ -286,42 +287,5 @@ QUnit.test('wrap will wrap a function inside of the mountpoint', assert => {
 
   let inner = root.firstElementChild.firstElementChild;
   run();
-  assert.equal(inner.textContent, 'works');
-});
-
-QUnit.test('wrap will wrap an async function inside of the mountpoint', async assert => {
-  let root = document.createElement('main');
-  root.innerHTML = `<div id="app"><div id="inner"></div></div>`;
-  let run;
-  class One {
-    constructor(_p, { wrapAsync }) {
-      run = wrapAsync(() => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            this.text = 'works';
-            resolve();
-          }, 5);
-        });
-      });
-    }
-
-    bind() {
-      const { text = 'does not work' } = this;
-      return sheet`
-        #inner {
-          text: ${text};
-        }
-      `;
-    }
-  }
-  sheet`
-    #app {
-      behavior: mount(${One});
-    }
-  `.update(root);
-
-  let inner = root.firstElementChild.firstElementChild;
-  let p = run();
-  await p;
   assert.equal(inner.textContent, 'works');
 });


### PR DESCRIPTION
Instead of wrapping a function, just provide a direct rebind()