### PR TITLE
Adds support for stores

### DIFF
--- a/.changeset/tidy-cameras-rush.md
+++ b/.changeset/tidy-cameras-rush.md
@@ -1,0 +1,7 @@
+---
+"corset": minor
+---
+
+Adds support for Stores
+
+This change adds a new feature "stores". A store is a Map that can be created in any scope within a sheet. The Map will be shared within JS inside of a behavior. It can be passed to child behaviors (through inputProperties) and when a child behavior modifies it, it will rebind() the parent behavior as well.

--- a/src/bindings.js
+++ b/src/bindings.js
@@ -52,6 +52,10 @@ export class Bindings {
     this.mount = null;
     /** @type {MultiBinding<string> | null} */
     this.prop = null;
+    /** @type {Binding | null} */
+    this.storeRoot = null;
+    /** @type {Binding | null} */
+    this.storeSet = null;
 
     /** @type {Map<string, Binding>} */
     this.custom = new Map();

--- a/src/function.js
+++ b/src/function.js
@@ -99,7 +99,9 @@ class ScopeLookupFunction {
    * @param {string} propName
    */
    constructor(dataName, propName) {
+    /** @type {string} */
     this.dataPropName = 'data-corset-' + dataName;
+    /** @type {string} */
     this.dataSelector = '[' + this.dataPropName + ']';
     /** @type {string} */
     this.propName = propName;
@@ -159,6 +161,31 @@ registerFunction.call(registry, 'item', class extends ScopeLookupFunction {
 registerFunction.call(registry, 'index', class extends ScopeLookupFunction {
   constructor() {
     super('index', 'corsetIndex');
+  }
+});
+
+registerFunction.call(registry, 'store-get', class extends ScopeLookupFunction {
+  constructor() {
+    super('', '');
+    this.keyValue = NO_VALUE;
+  }
+  check(...args) {
+    const [storeName, key] = args[0];
+    /** @type {string} */
+    this.dataPropName = 'data-corset-store';
+    /** @type {string} */
+    this.dataSelector = '[' + this.dataPropName + '=' + storeName + ']';
+    /** @type {string} */
+    this.propName = `corset.store.${storeName}`;
+    let dirty = super.check(...args);
+    if(this.value && this.keyValue !== this.value.get(key)) {
+      this.keyValue = this.value.get(key);
+      return true;
+    }
+    return dirty;
+  }
+  call() {
+    return this.keyValue;
   }
 });
 

--- a/src/function.js
+++ b/src/function.js
@@ -5,7 +5,7 @@ import { createValueTemplate } from './template.js';
 import { ComputedValue } from './compute.js';
 import { registry as behaviorRegistry } from './mount.js';
 import { lookup } from './scope.js';
-import { storeDataName, storeDataPropName, storePropName } from './store.js';
+import { storeDataName, storePropName } from './store.js';
 
 /**
  * @typedef {import('./binding').Binding} Binding
@@ -122,7 +122,7 @@ class ScopeLookupFunction {
     let check = false;
     if(changeset.selectors) check = true;
     if(check) {
-      let value = this.#get(element);
+      let value = lookup(element, this.dataPropName, this.dataSelector, this.propName);
       if(value !== this.value) {
         this.value = value;
         return true;
@@ -136,21 +136,6 @@ class ScopeLookupFunction {
    */
   call() {
     return this.value;
-  }
-  /**
-   * 
-   * @param {Element} element 
-   * @returns 
-   */
-  #get(element) {
-    /** @type {Element | null} */
-    let el = element;
-    do {
-      if(el.hasAttribute(this.dataPropName)) {
-        return /** @type {any} */(el)[Symbol.for(this.propName)];
-      }
-      el = element.closest(this.dataSelector);
-    } while(el);
   }
 }
 

--- a/src/function.js
+++ b/src/function.js
@@ -168,41 +168,66 @@ registerFunction.call(registry, 'index', class extends ScopeLookupFunction {
 
 registerFunction.call(registry, 'store-get', class {
   constructor() {
-    this.mapValue = undefined;
-    this.keyValue = NO_VALUE;
+    /** @type {any} */
+    this.value = undefined;
   }
   /**
    * 
-   * @param {[string, string]} param0
+   * @param {[string, string]} _args
    * @param {Map<string, any>} _props
    * @param {FunctionContext} param1
    * @param {Changeset} changeset
    * @returns {boolean}
    */
   check([storeName, key], _props, { element }, changeset) {
-    let check = false, dirty = false;
-    if(changeset.selectors) check = true;
+    let check = changeset.selectors;
     if(check) {
       let dataName = storeDataName(storeName);
       /** @type {Map<string, any> | undefined} */
       let map = lookup(element, dataName, `[${dataName}]`, storePropName(storeName));
-      dirty = map !== this.mapValue;
-      if(dirty) {
-        this.mapValue = map;
-      }
-      if(this.keyValue !== this.mapValue?.get(key)) {
-        this.keyValue = this.mapValue?.get(key);
+      if(map?.get(key) !== this.value) {
+        this.value = map?.get(key);
         return true;
       }
     }
-    return dirty;
+    return false;
+  }
+  call() {
+    return this.value;
+  }
+});
+
+registerFunction.call(registry, 'store', class {
+  constructor() {
+    /** @type {Map<any, any> | undefined} */
+    this.map = undefined;
   }
   /**
    * 
-   * @returns {any}
+   * @param {[string]} _args
+   * @param {Map<string, any>} _props
+   * @param {FunctionContext} param1
+   * @param {Changeset} changeset
+   * @returns {boolean}
+   */
+   check([storeName], _props, { element }, changeset) {
+    let check = changeset.selectors;
+    if(check) {
+      let dataName = storeDataName(storeName);
+      /** @type {Map<any, any> | undefined} */
+      let map = lookup(element, dataName, `[${dataName}]`, storePropName(storeName));
+      if(map !== this.map) {
+        this.map = map;
+        return true;
+      }
+    }
+    return false;
+  }
+  /**
+   * @returns {Map<any, any> | undefined}
    */
   call() {
-    return this.keyValue;
+    return this.map;
   }
 });
 

--- a/src/mount.js
+++ b/src/mount.js
@@ -50,6 +50,8 @@ export function BehaviorContext(mp) {
   this.element = mp.rootElement;
   /** @type {() => void} */
   this.rebind = mp.update.bind(mp);
+  /** @type {Map<string, Map<string, any>>} */
+  this.stores = new Map();
 }
 
 export class Mountpoint {

--- a/src/property.d.ts
+++ b/src/property.d.ts
@@ -10,7 +10,9 @@ type PropertyPropName = 'attr' |
   'each' |
   'event' |
   'prop' |
-  'text'
+  'text' |
+  'storeRoot' |
+  'storeSet'
 
 interface BasePropertyDefinition {
   flag: number;

--- a/src/property.d.ts
+++ b/src/property.d.ts
@@ -79,7 +79,9 @@ export declare const flags: Record<
   'prop' |
   'attr' |
   'data' |
-  'attach'
+  'attach' |
+  'storeRoot' |
+  'storeSet'
 , number>;
 
 type featureNames = 'keyed' | 'multi' | 'oldValues' | 'longhand' | 'behavior';

--- a/src/property.js
+++ b/src/property.js
@@ -10,7 +10,9 @@ export const flags = {
   attr: 1 << 6,
   data: 1 << 7,
   attach: 1 << 8,
-  behavior: 1 << 9
+  behavior: 1 << 9,
+  storeRoot: 1 << 10,
+  storeSet: 1 << 11
 };
 
 /**
@@ -220,4 +222,17 @@ export const properties = {
       return el.textContent;
     }
   },
+   /** @type {SimplePropertyDefinition} */
+  'store-root': {
+    flag: flags.storeRoot,
+    feat: 0,
+    prop: 'storeRoot',
+    read: () => null
+  },
+  'store-set': {
+    flag: flags.storeSet,
+    feat: 0,
+    prop: 'storeSet',
+    read: () => null
+  }
 };

--- a/src/property.js
+++ b/src/property.js
@@ -229,6 +229,7 @@ export const properties = {
     prop: 'storeRoot',
     read: () => null
   },
+  /** @type {SimplePropertyDefinition} */
   'store-set': {
     flag: flags.storeSet,
     feat: 0,

--- a/src/render.js
+++ b/src/render.js
@@ -62,22 +62,33 @@ function render(element, bindings, root, changeset) {
 
     let binding = /** @type {Binding} */(bindings.storeRoot);
     if(binding.dirty(changeset)) {
+      let oldValue = binding.value;
       let storeName = binding.update(changeset);
-      element.dataset[storeDataPropName(storeName)] = '';
-      let map = new Store(root);
-      /** @type {any} */
-      (element)[Symbol.for(storePropName(storeName))] = map;
-      root.mount?.context?.stores.set(storeName, map);
+      if(storeName) {
+        element.dataset[storeDataPropName(storeName)] = '';
+        let map = new Store(root);
+        /** @type {any} */
+        (element)[Symbol.for(storePropName(storeName))] = map;
+        root.mount?.context?.stores.set(storeName, map);
+      } else {
+        delete element.dataset[storeDataPropName(oldValue)];
+        delete /** @type {any} */(element)[Symbol.for(storePropName(oldValue))];
+        root.mount?.context?.stores.delete(oldValue);
+        invalid = true;
+      }
     }
   }
 
   if(bflags & flags.storeSet) {
     let binding = /** @type {Binding} */(bindings.storeSet);
     if(binding.dirty(changeset)) {
-      let [storeName, key, value] = binding.update(changeset);
-      let dataName = storeDataName(storeName);
-      let map = lookup(element, dataName, `[${dataName}]`, storePropName(storeName));
-      map?.set(key, value);
+      let args = binding.update(changeset);
+      if(args) {
+        let [storeName, key, value] = args;
+        let dataName = storeDataName(storeName);
+        let map = lookup(element, dataName, `[${dataName}]`, storePropName(storeName));
+        map?.set(key, value);
+      }
       invalid = true;
     }
   }

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,7 @@ import { EachInstance } from './each.js';
 import { datasetPropKey } from './custom-prop.js';
 import { Mountpoint } from './mount.js';
 import { lookup } from './scope.js';
+import { storePropName, storeDataName, storeDataPropName, Store } from './store.js';
 
 /**
  * @typedef {import('./binding').Binding} Binding
@@ -62,9 +63,11 @@ function render(element, bindings, root, changeset) {
     let binding = /** @type {Binding} */(bindings.storeRoot);
     if(binding.dirty(changeset)) {
       let storeName = binding.update(changeset);
-      element.dataset['corsetStore'] = storeName;
+      element.dataset[storeDataPropName(storeName)] = '';
+      let map = new Store(root);
       /** @type {any} */
-      (element)[Symbol.for(`corset.store.${storeName}`)] = new Map();
+      (element)[Symbol.for(storePropName(storeName))] = map;
+      root.mount?.context?.stores.set(storeName, map);
     }
   }
 
@@ -72,7 +75,8 @@ function render(element, bindings, root, changeset) {
     let binding = /** @type {Binding} */(bindings.storeSet);
     if(binding.dirty(changeset)) {
       let [storeName, key, value] = binding.update(changeset);
-      let map = lookup(element, 'data-corset-store', `[data-corset-store='${storeName}']`, `corset.store.${storeName}`);
+      let dataName = storeDataName(storeName);
+      let map = lookup(element, dataName, `[${dataName}]`, storePropName(storeName));
       map?.set(key, value);
       invalid = true;
     }

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,18 @@
+
+/**
+ * 
+ * @param {string} dataPropName 
+ * @param {string} dataSelector 
+ * @param {string} propName 
+ * @returns 
+ */
+export function lookup(element, dataPropName, dataSelector, propName) {
+  /** @type {Element | null} */
+  let el = element;
+  do {
+    if(el.hasAttribute(dataPropName)) {
+      return /** @type {any} */(el)[Symbol.for(propName)];
+    }
+    el = element.closest(dataSelector);
+  } while(el);
+}

--- a/src/sheet.js
+++ b/src/sheet.js
@@ -36,16 +36,28 @@ export class Root {
     this.bindingMap = new Map();
     /** @type {(a: () => any) => any} */
     this.getCallback = this.mount ? this.mount.getCallback.bind(this.mount) : identity;
+    /** @type {number} */
+    this.queue = 0;
+    /** @type {any[] | null} */
+    this.values = null;
+
   }
   /**
    * @param {any[]} values
    */
   update(values) {
-    let invalid = true;
-    while(invalid) {
-      let changeset = new Changeset(values);
-      this.collect();
-      invalid = renderRoot(this.bindingMap, this, changeset);
+    this.values = values;
+    this.queue++;
+    if(this.queue > 1) return;
+    while(this.queue) {
+      let invalid = true;
+      while(invalid) {
+        let changeset = new Changeset(this.values);
+        this.collect();
+        invalid = renderRoot(this.bindingMap, this, changeset);
+      }
+      this.queue--;
+      if(this.queue) this.queue = 1;
     }
   }
   /**

--- a/src/sheet.js
+++ b/src/sheet.js
@@ -36,28 +36,17 @@ export class Root {
     this.bindingMap = new Map();
     /** @type {(a: () => any) => any} */
     this.getCallback = this.mount ? this.mount.getCallback.bind(this.mount) : identity;
-    /** @type {number} */
-    this.queue = 0;
-    /** @type {any[] | null} */
-    this.values = null;
 
   }
   /**
    * @param {any[]} values
    */
   update(values) {
-    this.values = values;
-    this.queue++;
-    if(this.queue > 1) return;
-    while(this.queue) {
-      let invalid = true;
-      while(invalid) {
-        let changeset = new Changeset(this.values);
-        this.collect();
-        invalid = renderRoot(this.bindingMap, this, changeset);
-      }
-      this.queue--;
-      if(this.queue) this.queue = 1;
+    let invalid = true;
+    while(invalid) {
+      let changeset = new Changeset(values);
+      this.collect();
+      invalid = renderRoot(this.bindingMap, this, changeset);
     }
   }
   /**

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,51 @@
+// @ts-check
+import { pascalCase } from './custom-prop.js';
+
+/**
+ * @typedef {import('./sheet').Root} Root
+ */
+
+export class Store extends Map {
+  /**
+   * 
+   * @param {Root} root 
+   */
+  constructor(root) {
+    super();
+    /** @type {Root} */
+    this.root = root;
+  }
+  rebind() {
+    this.root.mount?.update();
+  }
+  /**
+   * 
+   * @param {string} k 
+   * @param {any} v 
+   * @returns 
+   */
+  set(k, v) {
+    super.set(k, v);
+    this.rebind();
+    return this;
+  }
+}
+
+/**
+ * 
+ * @param {string} storeName 
+ * @returns {string}
+ */
+export const storePropName = storeName => `corset.store.${storeName}`;
+/**
+ * 
+ * @param {string} storeName 
+ * @returns {string}
+ */
+export const storeDataName = storeName => `data-corset-store-${storeName}`;
+/**
+ * 
+ * @param {string} storeName 
+ * @returns {string}
+ */
+export const storeDataPropName = storeName => 'corsetStore' + pascalCase('-' + storeName);

--- a/src/value.js
+++ b/src/value.js
@@ -125,7 +125,7 @@ export class PlaceholderValue {
    */
   #get(args, { element }) {
     let [propName] = args;
-    let dataName = 'prop-' + propName.substr(2);
+    let dataName = 'prop-' + propName.slice(2);
     let dataPropName = 'data-corset-' + dataName;
     let dataSelector = '[' + dataPropName + ']';
     return lookup(element, dataPropName, dataSelector, propName);

--- a/src/value.js
+++ b/src/value.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { lookup } from './scope.js';
 
 /**
  * @typedef {import('./binding').Binding} Binding
@@ -127,15 +128,7 @@ export class PlaceholderValue {
     let dataName = 'prop-' + propName.substr(2);
     let dataPropName = 'data-corset-' + dataName;
     let dataSelector = '[' + dataPropName + ']';
-    /** @type {Element | null} */
-    let el = element;
-    do {
-      if(el.hasAttribute(dataPropName)) {
-        let scope = /** @type {any} */ (el)[Symbol.for(propName)];
-        return scope;
-      }
-      el = element.closest(dataSelector);
-    } while(el);
+    return lookup(element, dataPropName, dataSelector, propName);
   }
   get() {
     return this.value;

--- a/test/test-store.js
+++ b/test/test-store.js
@@ -1,6 +1,6 @@
-import sheet from '../src/main.js';
+import sheet, { mount } from '../src/main.js';
 
-QUnit.module('Property - store-root');
+QUnit.module('Property - store-root, store-set');
 
 QUnit.test('Sets the root location of a store', assert => {
   let root = document.createElement('main');
@@ -13,6 +13,40 @@ QUnit.test('Sets the root location of a store', assert => {
     }
   `;
   bindings.update(root);
-  console.log(root);
   assert.equal(root.firstElementChild.textContent, 'bar');
+});
+
+QUnit.test('Are accessible with JS; setting values in JS updates the mountpoint', assert => {
+  let root = document.createElement('main');
+  root.innerHTML = `<div id="app"><div class="child"><button></button></div><div class="sibling"></div></div>`;
+  let change;
+  mount(root, class {
+    constructor(props, { stores }) {
+      change = () => stores.get('app')?.set('name', 'Matthew');
+    }
+    bind(props, { stores }) {
+      return sheet`
+        #app {
+          --app: "testing";
+          store-root: app;
+        }
+
+        .child {
+          store-set: app name "Wilbur";
+        }
+
+        .child button {
+          event[some-event]: ${() => stores.get('app')?.set('name', 'Anne')};
+        }
+
+        .sibling {
+          text: store-get(app, name);
+        }
+      `;
+    }
+  });
+  change();
+  assert.equal(root.querySelector('.sibling').textContent, 'Matthew');
+  root.querySelector('.child button').dispatchEvent(new CustomEvent('some-event'));
+  assert.equal(root.querySelector('.sibling').textContent, 'Anne');
 });

--- a/test/test-store.js
+++ b/test/test-store.js
@@ -1,0 +1,18 @@
+import sheet from '../src/main.js';
+
+QUnit.module('Property - store-root');
+
+QUnit.test('Sets the root location of a store', assert => {
+  let root = document.createElement('main');
+  root.innerHTML = `<div id="app"></div>`;
+  let bindings = sheet`
+    #app {
+      store-root: app;
+      store-set: app foo bar;
+      text: store-get(app, foo);
+    }
+  `;
+  bindings.update(root);
+  console.log(root);
+  assert.equal(root.firstElementChild.textContent, 'bar');
+});

--- a/test/test.html
+++ b/test/test.html
@@ -31,5 +31,6 @@
   import "./test-behavior.js";
   import "./test-var.js";
   import "./test-custom-function.js";
+  import "./test-store.js";
   QUnit.start();
 </script>


### PR DESCRIPTION
Closes #108 

This adds support for stores through `store-root`, `store-set`, `store-get()`, and `store()`, that can be used to hold mutable values that can be shared with child behaviors and between a Corset sheet and JS.