### PR TITLE
Allow multiple bindings with store-set

### DIFF
--- a/.changeset/rare-emus-grin.md
+++ b/.changeset/rare-emus-grin.md
@@ -1,0 +1,15 @@
+---
+"corset": minor
+---
+
+Allow multiple store-set within a rule
+
+```css
+#app {
+  store-root: app;
+  store-set: app first "Wilbur";
+  store-set: app last "Phillips";
+  --full-name: store-get(app, first) " " store-get(app, last);
+  text: var(--full-name);
+}
+```

--- a/src/pinfo.ts
+++ b/src/pinfo.ts
@@ -1,3 +1,4 @@
+import type { Constant } from './constants';
 
 export type PropertyPropName = 'attr' |
   'attrValue' |
@@ -26,7 +27,8 @@ export interface MultiPropertyDefinition extends BasePropertyDefinition {
   read: ReadKeyedValue;
   longhand?: never;
   shorthand?: never;
-  prop: 'classToggle' | 'data' | 'prop';
+  prop: 'classToggle' | 'data' | 'prop' | 'storeSet';
+  key?: (values: any[]) => string | Constant;
 }
 
 export interface BehaviorMultiPropertyDefinition extends BasePropertyDefinition {

--- a/src/property.js
+++ b/src/property.js
@@ -1,13 +1,21 @@
 // @ts-check
 
 /**
+ * @typedef {import('./constants').Constant} Constant
  * @typedef {import('./pinfo').PropertyDefinition} PropertyDefinition
  * @typedef {import('./pinfo').SimplePropertyDefinition} SimplePropertyDefinition
  * @typedef {import('./pinfo').ShorthandPropertyDefinition} ShorthandPropertyDefinition
  * @typedef {import('./pinfo').LonghandPropertyDefinition} LonghandPropertyDefinition
  * @typedef {import('./pinfo').MultiPropertyDefinition} MultiPropertyDefinition
  * @typedef {import('./pinfo').BehaviorMultiPropertyDefinition} BehaviorMultiPropertyDefinition
+ * 
+ * @typedef {(values: any[]) => string | Constant} KeyReader
  */
+
+/** @type {KeyReader} */
+export const keySimple = (values) => values[0];
+/** @type {KeyReader} */
+export const keyCompound = (values) => values[0] + values[1];
 
 export const flags = {
   text: 1 << 0,
@@ -54,7 +62,7 @@ export const properties = {
     feat: features.multi | features.shorthand | features.keyed,
     prop: 'attr',
     longhand: ['attr-value', 'attr-toggle'],
-    defaults: ['', true]
+    defaults: ['', true],
   },
   /** @type {LonghandPropertyDefinition} */
   'attr-value': {
@@ -104,7 +112,7 @@ export const properties = {
     feat: features.shorthand,
     prop: 'each',
     longhand: ['each-items', 'each-template', 'each-key'],
-    defaults: [[], {}, null]
+    defaults: [[], {}, null],
   },
   'each-items': {
     flag: flags.each,
@@ -137,7 +145,7 @@ export const properties = {
     prop: 'event',
     longhand: ['event-type', 'event-listener', 'event-capture', 'event-once',
       'event-passive', 'event-signal'],
-    defaults: [null, false, false, false, undefined]
+    defaults: [null, false, false, false, undefined],
   },
   'event-type': {
     flag: flags.event,
@@ -218,11 +226,12 @@ export const properties = {
     prop: 'storeRoot',
     read: () => null
   },
-  /** @type {SimplePropertyDefinition} */
+  /** @type {MultiPropertyDefinition} */
   'store-set': {
     flag: flags.storeSet,
-    feat: 0,
+    feat: features.multi | features.keyed,
     prop: 'storeSet',
+    key: keyCompound,
     read: () => null
-  }
+  },
 };

--- a/src/render.js
+++ b/src/render.js
@@ -86,14 +86,10 @@ function render(element, bindings, root, changeset) {
   }
 
   if(bflags & flags.storeSet) {
-    let binding = /** @type {Binding} */(bindings.storeSet);
-    if(binding.dirty(changeset)) {
-      let args = binding.update(changeset);
-      if(args) {
-        let [storeName, key, value] = args;
-        let map = lookup(element, storeDataSelector(storeName), storePropName(storeName));
-        map?.set(key, value);
-      }
+    let binding = /** @type {KeyedMultiBinding} */(bindings.storeSet);
+    for(let [storeName, key, value] of binding.changes(changeset)) {
+      let map = lookup(element, storeDataSelector(storeName), storePropName(storeName));
+      map?.set(key, value);
       invalid = true;
     }
   }

--- a/test/test-store.js
+++ b/test/test-store.js
@@ -195,8 +195,8 @@ QUnit.test('Can be used to set vars', assert => {
     #app {
       store-root: app;
       store-set: app first "Wilbur";
-
-      --full-name: store-get(app, first) " " "Phillips";
+      store-set: app last "Phillips";
+      --full-name: store-get(app, first) " " store-get(app, last);
       text: var(--full-name);
     }
   `.update(root);


### PR DESCRIPTION
This change makes it so that you can use multiple `store-set` calls within the same selector.

```css
#app {
  store-root: app;
  store-set: app first "Wilbur";
  store-set: app last "Phillips";
  --full-name: store-get(app, first) " " store-get(app, last);
  text: var(--full-name);
}
```